### PR TITLE
Split the integration.config['connections'] to new models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,14 +41,14 @@ gem 'bootsnap', '>= 1.1.0', require: false
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'rspec-rails', '~> 4.0.2'
 end
 
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'web-console', '>= 3.3.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
@@ -60,7 +60,8 @@ group :test do
   gem 'selenium-webdriver'
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'chromedriver-helper'
+  gem 'shoulda-matchers', '~> 4.0'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    shoulda-matchers (4.5.1)
+      activesupport (>= 4.2.0)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -261,6 +263,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0.2)
   sass-rails (~> 5.0)
   selenium-webdriver
+  shoulda-matchers (~> 4.0)
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
@@ -272,4 +275,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.1.4
+   2.2.14

--- a/app/models/connection.rb
+++ b/app/models/connection.rb
@@ -1,3 +1,4 @@
 class Connection < ApplicationRecord
   belongs_to :integration
+  has_many :field_mappings
 end

--- a/app/models/connection.rb
+++ b/app/models/connection.rb
@@ -1,4 +1,8 @@
 class Connection < ApplicationRecord
   belongs_to :integration
   has_many :field_mappings
+
+  def path
+    @path ||= OpenStruct.new(super).freeze
+  end
 end

--- a/app/models/connection.rb
+++ b/app/models/connection.rb
@@ -1,0 +1,3 @@
+class Connection < ApplicationRecord
+  belongs_to :integration
+end

--- a/app/models/field_mapping.rb
+++ b/app/models/field_mapping.rb
@@ -1,0 +1,3 @@
+class FieldMapping < ApplicationRecord
+  belongs_to :connection
+end

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -1,4 +1,6 @@
 class Integration < ApplicationRecord
+  has_many :connections
+
   def connections
     config['connections'].map do |connection|
       auth = OpenStruct.new(connection['auth'])

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -1,15 +1,3 @@
 class Integration < ApplicationRecord
   has_many :connections
-  #
-  # def connections
-  #   config['connections'].map do |connection|
-  #     auth = OpenStruct.new(connection['auth'])
-  #     path = OpenStruct.new(connection['path'])
-  #     field_mappings = connection['field_mapping'].map do |mapping|
-  #       OpenStruct.new(local_field: mapping[0], external_field: mapping[1])
-  #     end
-  #
-  #     OpenStruct.new(auth: auth, path: path, field_mappings: field_mappings)
-  #   end
-  # end
 end

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -1,15 +1,15 @@
 class Integration < ApplicationRecord
   has_many :connections
-
-  def connections
-    config['connections'].map do |connection|
-      auth = OpenStruct.new(connection['auth'])
-      path = OpenStruct.new(connection['path'])
-      field_mappings = connection['field_mapping'].map do |mapping|
-        OpenStruct.new(local_field: mapping[0], external_field: mapping[1])
-      end
-
-      OpenStruct.new(auth: auth, path: path, field_mappings: field_mappings)
-    end
-  end
+  #
+  # def connections
+  #   config['connections'].map do |connection|
+  #     auth = OpenStruct.new(connection['auth'])
+  #     path = OpenStruct.new(connection['path'])
+  #     field_mappings = connection['field_mapping'].map do |mapping|
+  #       OpenStruct.new(local_field: mapping[0], external_field: mapping[1])
+  #     end
+  #
+  #     OpenStruct.new(auth: auth, path: path, field_mappings: field_mappings)
+  #   end
+  # end
 end

--- a/db/migrate/20210318094339_create_connections.rb
+++ b/db/migrate/20210318094339_create_connections.rb
@@ -1,0 +1,11 @@
+class CreateConnections < ActiveRecord::Migration[5.2]
+  def change
+    create_table :connections do |t|
+      t.jsonb :auth
+      t.jsonb :path
+      t.belongs_to :integration, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210318095221_create_field_mappings.rb
+++ b/db/migrate/20210318095221_create_field_mappings.rb
@@ -1,0 +1,11 @@
+class CreateFieldMappings < ActiveRecord::Migration[5.2]
+  def change
+    create_table :field_mappings do |t|
+      t.string :local_field
+      t.string :external_field
+      t.belongs_to :connection, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_18_094339) do
+ActiveRecord::Schema.define(version: 2021_03_18_095221) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,15 @@ ActiveRecord::Schema.define(version: 2021_03_18_094339) do
     t.index ["integration_id"], name: "index_connections_on_integration_id"
   end
 
+  create_table "field_mappings", force: :cascade do |t|
+    t.string "local_field"
+    t.string "external_field"
+    t.bigint "connection_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["connection_id"], name: "index_field_mappings_on_connection_id"
+  end
+
   create_table "integrations", force: :cascade do |t|
     t.string "name"
     t.jsonb "config", default: {}, comment: "Arbitrary JSON that the FE will parse to generate layout data"
@@ -32,4 +41,5 @@ ActiveRecord::Schema.define(version: 2021_03_18_094339) do
   end
 
   add_foreign_key "connections", "integrations"
+  add_foreign_key "field_mappings", "connections"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_24_135959) do
+ActiveRecord::Schema.define(version: 2021_03_18_094339) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "connections", force: :cascade do |t|
+    t.jsonb "auth"
+    t.jsonb "path"
+    t.bigint "integration_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["integration_id"], name: "index_connections_on_integration_id"
+  end
 
   create_table "integrations", force: :cascade do |t|
     t.string "name"
@@ -22,4 +31,5 @@ ActiveRecord::Schema.define(version: 2021_02_24_135959) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "connections", "integrations"
 end

--- a/lib/tasks/integration_data.rake
+++ b/lib/tasks/integration_data.rake
@@ -1,0 +1,24 @@
+namespace :integration_data do
+  desc "Copy Integration#config['connections'] to Integration#connections"
+  task migrate: :environment do
+    Integration.transaction do
+      Integration.find_each do |integration|
+        integration.config['connections'].each do |config_conn|
+          # To avoid creating duplicates if this task gets run multiple times
+          # find the connection with the same attributes before creating it
+          connection = integration.connections.find_or_create_by(config_conn.slice('auth', 'path'))
+
+          config_conn['field_mapping'].each do |local_field, external_field|
+            mapping = { local_field: local_field,
+                        external_field: external_field }
+
+            # Filed mappings are uniq per connection so don't create duplicates
+            next if connection.field_mappings.exists?(mapping)
+
+            connection.field_mappings.create(mapping)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/app/models/connection_spec.rb
+++ b/spec/app/models/connection_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 RSpec.describe Connection, type: :model do
   it { should belong_to(:integration) }
+  it { should have_many(:field_mappings) }
 end

--- a/spec/app/models/connection_spec.rb
+++ b/spec/app/models/connection_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Connection, type: :model do
+  it { should belong_to(:integration) }
+end

--- a/spec/app/models/integration_spec.rb
+++ b/spec/app/models/integration_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Integration, type: :model do
+  it { should have_many(:connections) }
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -30,6 +30,14 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
## Architecture
The task is to split the `integration.config` so that the `field_mapping` elements of a connection become separate records while keeping the relation to the `path` field in the connection object.
From what I understood, a connection is defined by the `auth` and the `path`. The `auth` for the two example objects is the same, thus it could be extracted to their own model. But since there is no requirement for that in the description I kept it in the connection model.

I wrote unit tests for connection and integration using matchers from the `shoulda-matcher` gem to make sure that a `connection` belongs to an `integration` and an `integration` has many `connections` and a `connection` has many `field_mappings` and a `field_mapping` belongs to one `connection`.

Didn't add tests for `auth` or `path` because there is no need for that. `auth` is not used in the code and I don't know how it is used and `path` is already covered in the `request` spec. A best practice is that code should be covered with as few tests as possible to avoid coupling between code and tests.

## How to run
1. `rails db:create db:migrate db:seed` 
2. `rails integration_data:migrate`
3. `rspec`