### PR TITLE
Split integration config column

### DIFF
--- a/app/api/api/entities/integration.rb
+++ b/app/api/api/entities/integration.rb
@@ -12,8 +12,7 @@ module API
       private
 
       def joined_path
-        path = object.path
-        [path.host, path.database, path.table].join('.')
+        [object.host, object.database, object.table].join('.')
       end
     end
 

--- a/app/models/connection.rb
+++ b/app/models/connection.rb
@@ -1,0 +1,9 @@
+class Connection < ApplicationRecord
+  # associations
+  belongs_to :integration
+  has_many :field_mappings, dependent: :destroy
+
+  # store and accessors
+  store :auth, accessors: [:username, :password], coder: JSON
+  store :path, accessors: [:host, :database, :table], coder: JSON
+end

--- a/app/models/field_mapping.rb
+++ b/app/models/field_mapping.rb
@@ -1,0 +1,4 @@
+class FieldMapping < ApplicationRecord
+  # associations
+  belongs_to :connection
+end

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -1,13 +1,4 @@
 class Integration < ApplicationRecord
-  def connections
-    config['connections'].map do |connection|
-      auth = OpenStruct.new(connection['auth'])
-      path = OpenStruct.new(connection['path'])
-      field_mappings = connection['field_mapping'].map do |mapping|
-        OpenStruct.new(local_field: mapping[0], external_field: mapping[1])
-      end
-
-      OpenStruct.new(auth: auth, path: path, field_mappings: field_mappings)
-    end
-  end
+  # associations
+  has_many :connections, dependent: :destroy
 end

--- a/db/migrate/20210512130753_create_connection.rb
+++ b/db/migrate/20210512130753_create_connection.rb
@@ -1,0 +1,11 @@
+class CreateConnection < ActiveRecord::Migration[5.2]
+  def change
+    create_table :connections do |t|
+      t.string :auth
+      t.string :path
+      t.references :integration
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210512130907_create_field_mapping.rb
+++ b/db/migrate/20210512130907_create_field_mapping.rb
@@ -1,0 +1,11 @@
+class CreateFieldMapping < ActiveRecord::Migration[5.2]
+  def change
+    create_table :field_mappings do |t|
+      t.string :local_field
+      t.string :external_field
+      t.references :connection, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_24_135959) do
+ActiveRecord::Schema.define(version: 2021_05_12_130907) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "connections", force: :cascade do |t|
+    t.string "auth"
+    t.string "path"
+    t.bigint "integration_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["integration_id"], name: "index_connections_on_integration_id"
+  end
+
+  create_table "field_mappings", force: :cascade do |t|
+    t.string "local_field"
+    t.string "external_field"
+    t.bigint "connection_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["connection_id"], name: "index_field_mappings_on_connection_id"
+  end
 
   create_table "integrations", force: :cascade do |t|
     t.string "name"
@@ -22,4 +40,5 @@ ActiveRecord::Schema.define(version: 2021_02_24_135959) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "field_mappings", "connections"
 end

--- a/lib/tasks/integrations_connections_migration.rake
+++ b/lib/tasks/integrations_connections_migration.rake
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+namespace :integrations do
+  desc 'Migrate integrations config to use connections and field mappings tables'
+  task connections_migration: :environment do
+    BATCH_SIZE = ENV.fetch('BATCH_SIZE', 500)
+
+    Integration.find_each(batch_size: BATCH_SIZE) do |integration|
+      next if integration.config.nil?
+
+      config = integration.config.with_indifferent_access
+
+      Integration.transaction do
+        config[:connections].each do |connection|
+          db_connection = integration.connections.find_or_create_by!(auth: auth(connection[:auth]), path: path(connection[:path]))
+          connection[:field_mapping].each do |mapping|
+            next if db_connection.field_mappings.exists?(local_field: mapping[0], external_field: mapping[1])
+  
+            field_mapping = db_connection.field_mappings.create!(local_field: mapping[0],
+                                                          external_field: mapping[1])
+          end
+        end
+  
+        # reset the config column as we don't wan 2 places to hold the same
+        integration.update_columns(config: nil)
+      end
+    end
+  end
+
+  def auth(hash)
+    {
+      username: hash[:username],
+      password: hash[:password]
+    }
+  end
+
+  def path(hash)
+    {
+      host: hash[:host],
+      database: hash[:database],
+      table: hash[:table] 
+    }
+  end
+end


### PR DESCRIPTION
## Problem
Currently the current integrations table has `config` json column that holds `connections` and `field_mappings` info. with the current table structure doesn't scale if the integrations has many connections.
## Solution
Split the config json column info into 2 tables:
- `connections`
- `field_mappings`
So that a single integration has many connections and each connection has many field mappings.
## In this PR:
- DB migrations for `connections` and `field_mappings` tables.
- Rake task to migrate the existing integrations data to the new structure.
- Update `/api/integrations/:id` to use the new structure.
## Release steps:
- `bin/rake db:migrate`
- `bin/rake integrations:connections_migration` 
