### PR TITLE
Break down config(json) column of integrations table into further tables

### DIFF
--- a/app/api/api/entities/integration.rb
+++ b/app/api/api/entities/integration.rb
@@ -12,7 +12,8 @@ module API
       private
 
       def joined_path
-        path = object.path
+        config = object.config
+        path = config.path
         [path.host, path.database, path.table].join('.')
       end
     end

--- a/app/models/connection.rb
+++ b/app/models/connection.rb
@@ -1,0 +1,11 @@
+class Connection < ApplicationRecord
+  belongs_to :integration
+  has_many :field_mappings
+
+  def config
+    config_hash = super.with_indifferent_access
+    auth = OpenStruct.new(config_hash[:auth])
+    path = OpenStruct.new(config_hash[:path])
+    OpenStruct.new(auth: auth, path: path)
+  end
+end

--- a/app/models/field_mapping.rb
+++ b/app/models/field_mapping.rb
@@ -1,0 +1,11 @@
+class FieldMapping < ApplicationRecord
+  belongs_to :connection
+
+  def local_field
+    config[0]
+  end
+
+  def external_field
+    config[1]
+  end
+end

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -1,13 +1,3 @@
 class Integration < ApplicationRecord
-  def connections
-    config['connections'].map do |connection|
-      auth = OpenStruct.new(connection['auth'])
-      path = OpenStruct.new(connection['path'])
-      field_mappings = connection['field_mapping'].map do |mapping|
-        OpenStruct.new(local_field: mapping[0], external_field: mapping[1])
-      end
-
-      OpenStruct.new(auth: auth, path: path, field_mappings: field_mappings)
-    end
-  end
+  has_many :connections
 end

--- a/db/migrate/20210614181241_create_connections.rb
+++ b/db/migrate/20210614181241_create_connections.rb
@@ -1,0 +1,11 @@
+class CreateConnections < ActiveRecord::Migration[5.2]
+  def change
+    create_table :connections do |t|
+      t.jsonb :config,
+              default: {},
+              comment: 'Arbitrary JSON that the FE will parse to generate layout data'
+      t.references :integration, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210614181303_create_field_mappings.rb
+++ b/db/migrate/20210614181303_create_field_mappings.rb
@@ -1,0 +1,11 @@
+class CreateFieldMappings < ActiveRecord::Migration[5.2]
+  def change
+    create_table :field_mappings do |t|
+      t.jsonb :config,
+              default: {},
+              comment: 'Arbitrary JSON that the FE will parse to generate layout data'
+      t.references :connection, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_24_135959) do
+ActiveRecord::Schema.define(version: 2021_06_14_181303) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "connections", force: :cascade do |t|
+    t.jsonb "config", default: {}, comment: "Arbitrary JSON that the FE will parse to generate layout data"
+    t.bigint "integration_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["integration_id"], name: "index_connections_on_integration_id"
+  end
+
+  create_table "field_mappings", force: :cascade do |t|
+    t.jsonb "config", default: {}, comment: "Arbitrary JSON that the FE will parse to generate layout data"
+    t.bigint "connection_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["connection_id"], name: "index_field_mappings_on_connection_id"
+  end
 
   create_table "integrations", force: :cascade do |t|
     t.string "name"

--- a/lib/tasks/data_migration.rake
+++ b/lib/tasks/data_migration.rake
@@ -1,0 +1,22 @@
+namespace :data_migration do
+  # One time task, remove this task after running on all the environments.
+  desc 'Migrate data from integrations config to connections and field_mappings tables'
+  task integrations_config_transfer: :environment do
+    Integration.transaction do
+      Integration.find_each(batch_size: 100) do |integration|
+        connections = integration.config.with_indifferent_access.fetch(:connections, [])
+        connections.each do |connection|
+          field_mappings = connection.delete(:field_mapping)
+          c = Connection.create!(config: connection, integration_id: integration.id)
+          field_mappings.each do |f_m|
+            FieldMapping.create!(config: f_m, connection_id: c.id)
+          end
+        end
+        Rails.logger.info "Integrations_config_transfer: Total connections moved: #{connections.size} for integration: #{integration.id}"
+      end
+    end
+  rescue StandardError => e
+    Rails.logger.info  "Integrations_config_transfer: Unable to perform migration due to #{e.inspect}"
+    raise e
+  end
+end


### PR DESCRIPTION
### Problems covered
- [x] Add: Prompt 1 - Data model changes and migration
- [x] Add: Prompt 2 - Maintain the API Contact

### Explaination
Since the connections in the integrations are growing, to scale we need to split the connections and its attributes in further tables.

### To apply these changes in the database follow the steps below:
- ``` rake db:migrate ```
-  ``` rake data_migration:integrations_config_transfer RAILS_ENV=development ```  (Change the environment accordingly)
This rake task is a one-time task. After it has run on all the environments it can be removed and the config column of the integration's table can be discarded by adding a migration.


### Note
I have kept the config for connection and field_mapping in the form of JSON column only. If these are going to be fixed attributes we can convert them into separate columns. For example:
config in field_mapping can become attributes :local_field, :external_field
Similary config in the connections table can also be converted into separate columns.